### PR TITLE
Update release address (fixes #165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Because of this, our feature set is growing. File an issue or let us know in IRC
 
 ## Downloads
 
-- [Builds](http://helion3.com:8080/job/Prism/)
+- [Releases](http://github.com/prism/Prism/releases)
 
 If using Mongo, download the `Prism-(version)-all.jar` file. Otherwise, download `Prism-(version).jar`.
 


### PR DESCRIPTION
Change address from http://helion3.com:8080/job/Prism/ to https://github.com/prism/Prism/releases since Jenkins isn't used anymore.